### PR TITLE
Add backend skeleton in Go

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,40 @@
 # LogAnalysisSystem
+
+This project is a minimal skeleton for a Web-based log analysis backend. It follows the architecture proposed in the project description and demonstrates how to start building a system similar to Bugly or Sentry.
+
+## Features
+
+- **Upload endpoint**: `/api/upload` accepts `.tar.gz` files, extracts them and parses each line into memory.
+- **Analyze endpoint**: `/api/analyze` returns the parsed log entries. Query with `?level=ERROR` to filter by level.
+
+The backend is implemented in Go using the Gin framework. Parsed log entries are stored in memory for demonstration purposes.
+
+## Getting Started
+
+1. Install Go 1.20 or later.
+2. Initialize dependencies:
+   ```bash
+   cd backend
+   go mod tidy
+   ```
+   (Requires internet access to download Gin.)
+3. Run the server:
+   ```bash
+   go run ./cmd
+   ```
+4. Upload logs:
+   ```bash
+   curl -F "file=@sample.tar.gz" http://localhost:8080/api/upload
+   ```
+5. Query log entries:
+   ```bash
+   curl http://localhost:8080/api/analyze?level=ERROR
+   ```
+
+## Next Steps
+
+- Persist parsed logs in a database such as ClickHouse.
+- Add aggregation and dashboarding via a React or Vue frontend under `frontend/`.
+- Containerize with Docker and provide Kubernetes manifests.
+
+This repository only includes the backend skeleton. It can be extended to implement the full workflow described in the detailed plan.

--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"log"
+
+	"github.com/gin-gonic/gin"
+	"loganalysissystem/backend/pkg/processor"
+)
+
+func main() {
+	r := gin.Default()
+	r.POST("/api/upload", processor.UploadHandler)
+	r.GET("/api/analyze", processor.AnalyzeHandler)
+	log.Fatal(r.Run(":8080"))
+}

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,0 +1,5 @@
+module loganalysissystem
+
+go 1.20
+
+require github.com/gin-gonic/gin v1.9.1

--- a/backend/pkg/processor/processor.go
+++ b/backend/pkg/processor/processor.go
@@ -1,0 +1,124 @@
+package processor
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+type LogEntry struct {
+	Timestamp time.Time `json:"timestamp"`
+	Level     string    `json:"level"`
+	Message   string    `json:"message"`
+}
+
+var logs []LogEntry
+
+func UploadHandler(c *gin.Context) {
+	file, err := c.FormFile("file")
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	f, err := file.Open()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	defer f.Close()
+
+	if strings.HasSuffix(file.Filename, ".tar.gz") {
+		if err := extractTarGz(f); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+	} else {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "only .tar.gz supported"})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"message": "uploaded"})
+}
+
+func extractTarGz(r io.Reader) error {
+	gz, err := gzip.NewReader(r)
+	if err != nil {
+		return err
+	}
+	defer gz.Close()
+
+	tr := tar.NewReader(gz)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return err
+		}
+		if hdr.FileInfo().IsDir() {
+			continue
+		}
+		path := filepath.Join(os.TempDir(), hdr.Name)
+		os.MkdirAll(filepath.Dir(path), 0755)
+		f, err := os.Create(path)
+		if err != nil {
+			return err
+		}
+		if _, err := io.Copy(f, tr); err != nil {
+			f.Close()
+			return err
+		}
+		f.Close()
+		parseFile(path)
+	}
+	return nil
+}
+
+func parseFile(path string) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return
+	}
+	lines := strings.Split(string(data), "\n")
+	for _, line := range lines {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		var timestampStr, level, msg string
+		if strings.HasPrefix(line, "[") {
+			if idx := strings.Index(line, "]"); idx != -1 {
+				timestampStr = line[1:idx]
+				rest := strings.TrimSpace(line[idx+1:])
+				parts := strings.SplitN(rest, " ", 2)
+				if len(parts) == 2 {
+					level = parts[0]
+					msg = parts[1]
+				}
+			}
+		}
+		if level == "" {
+			level = "INFO"
+			msg = line
+		}
+		ts, _ := time.Parse(time.RFC3339, timestampStr)
+		logs = append(logs, LogEntry{Timestamp: ts, Level: level, Message: msg})
+	}
+}
+
+func AnalyzeHandler(c *gin.Context) {
+	level := c.Query("level")
+	var result []LogEntry
+	for _, l := range logs {
+		if level == "" || strings.EqualFold(l.Level, level) {
+			result = append(result, l)
+		}
+	}
+	c.JSON(http.StatusOK, result)
+}


### PR DESCRIPTION
## Summary
- initialize a Go module for the backend
- implement basic HTTP server with upload and analysis endpoints
- add sample log parsing logic
- document usage in README

## Testing
- `go fmt ./...`
- `go mod tidy` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684a9386f97c832092c848c0d0723dd8